### PR TITLE
Send message outside of handler

### DIFF
--- a/src/NServiceBus.AwsLambda.SQS.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.AwsLambda.SQS.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -4,6 +4,18 @@ namespace NServiceBus
     {
         public AwsLambdaSQSEndpoint(System.Func<Amazon.Lambda.Core.ILambdaContext, NServiceBus.AwsLambdaSQSEndpointConfiguration> configurationFactory) { }
         public System.Threading.Tasks.Task Process(Amazon.Lambda.SQSEvents.SQSEvent @event, Amazon.Lambda.Core.ILambdaContext lambdaContext, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task Publish(object message, Amazon.Lambda.Core.ILambdaContext lambdaContext) { }
+        public System.Threading.Tasks.Task Publish(object message, NServiceBus.PublishOptions options, Amazon.Lambda.Core.ILambdaContext lambdaContext) { }
+        public System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, Amazon.Lambda.Core.ILambdaContext lambdaContext) { }
+        public System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, NServiceBus.PublishOptions options, Amazon.Lambda.Core.ILambdaContext lambdaContext) { }
+        public System.Threading.Tasks.Task Send(object message, Amazon.Lambda.Core.ILambdaContext lambdaContext) { }
+        public System.Threading.Tasks.Task Send(object message, NServiceBus.SendOptions options, Amazon.Lambda.Core.ILambdaContext lambdaContext) { }
+        public System.Threading.Tasks.Task Send<T>(System.Action<T> messageConstructor, Amazon.Lambda.Core.ILambdaContext lambdaContext) { }
+        public System.Threading.Tasks.Task Send<T>(System.Action<T> messageConstructor, NServiceBus.SendOptions options, Amazon.Lambda.Core.ILambdaContext lambdaContext) { }
+        public System.Threading.Tasks.Task Subscribe(System.Type eventType, Amazon.Lambda.Core.ILambdaContext lambdaContext) { }
+        public System.Threading.Tasks.Task Subscribe(System.Type eventType, NServiceBus.SubscribeOptions options, Amazon.Lambda.Core.ILambdaContext lambdaContext) { }
+        public System.Threading.Tasks.Task Unsubscribe(System.Type eventType, Amazon.Lambda.Core.ILambdaContext lambdaContext) { }
+        public System.Threading.Tasks.Task Unsubscribe(System.Type eventType, NServiceBus.UnsubscribeOptions options, Amazon.Lambda.Core.ILambdaContext lambdaContext) { }
     }
     public class AwsLambdaSQSEndpointConfiguration
     {
@@ -19,5 +31,17 @@ namespace NServiceBus
     public interface IAwsLambdaSQSEndpoint
     {
         System.Threading.Tasks.Task Process(Amazon.Lambda.SQSEvents.SQSEvent @event, Amazon.Lambda.Core.ILambdaContext lambdaContext, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task Publish(object message, Amazon.Lambda.Core.ILambdaContext lambdaContext);
+        System.Threading.Tasks.Task Publish(object message, NServiceBus.PublishOptions options, Amazon.Lambda.Core.ILambdaContext lambdaContext);
+        System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, Amazon.Lambda.Core.ILambdaContext lambdaContext);
+        System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, NServiceBus.PublishOptions options, Amazon.Lambda.Core.ILambdaContext lambdaContext);
+        System.Threading.Tasks.Task Send(object message, Amazon.Lambda.Core.ILambdaContext lambdaContext);
+        System.Threading.Tasks.Task Send(object message, NServiceBus.SendOptions options, Amazon.Lambda.Core.ILambdaContext lambdaContext);
+        System.Threading.Tasks.Task Send<T>(System.Action<T> messageConstructor, Amazon.Lambda.Core.ILambdaContext lambdaContext);
+        System.Threading.Tasks.Task Send<T>(System.Action<T> messageConstructor, NServiceBus.SendOptions options, Amazon.Lambda.Core.ILambdaContext lambdaContext);
+        System.Threading.Tasks.Task Subscribe(System.Type eventType, Amazon.Lambda.Core.ILambdaContext lambdaContext);
+        System.Threading.Tasks.Task Subscribe(System.Type eventType, NServiceBus.SubscribeOptions options, Amazon.Lambda.Core.ILambdaContext lambdaContext);
+        System.Threading.Tasks.Task Unsubscribe(System.Type eventType, Amazon.Lambda.Core.ILambdaContext lambdaContext);
+        System.Threading.Tasks.Task Unsubscribe(System.Type eventType, NServiceBus.UnsubscribeOptions options, Amazon.Lambda.Core.ILambdaContext lambdaContext);
     }
 }

--- a/src/NServiceBus.AwsLambda.SQS/IAwsLambdaSQSEndpoint.cs
+++ b/src/NServiceBus.AwsLambda.SQS/IAwsLambdaSQSEndpoint.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus
+﻿using System;
+
+namespace NServiceBus
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -15,5 +17,68 @@
         /// Processes a messages received from an SQS trigger using the NServiceBus message pipeline.
         /// </summary>
         Task Process(SQSEvent @event, ILambdaContext lambdaContext, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends the provided message.
+        /// </summary>
+        Task Send(object message, SendOptions options, ILambdaContext lambdaContext);
+
+        /// <summary>
+        /// Sends the provided message.
+        /// </summary>
+        Task Send(object message, ILambdaContext lambdaContext);
+
+        /// <summary>
+        /// Instantiates a message of type T and sends it.
+        /// </summary>
+        Task Send<T>(Action<T> messageConstructor, SendOptions options, ILambdaContext lambdaContext);
+
+        /// <summary>
+        /// Instantiates a message of type T and sends it.
+        /// </summary>
+        Task Send<T>(Action<T> messageConstructor, ILambdaContext lambdaContext);
+
+        /// <summary>
+        /// Publish the message to subscribers.
+        /// </summary>
+        Task Publish(object message, PublishOptions options, ILambdaContext lambdaContext);
+
+        /// <summary>
+        /// Instantiates a message of type T and publishes it.
+        /// </summary>
+        Task Publish<T>(Action<T> messageConstructor, PublishOptions options, ILambdaContext lambdaContext);
+
+        /// <summary>
+        /// Instantiates a message of type T and publishes it.
+        /// </summary>
+        Task Publish(object message, ILambdaContext lambdaContext);
+
+        /// <summary>
+        /// Instantiates a message of type T and publishes it.
+        /// </summary>
+        Task Publish<T>(Action<T> messageConstructor, ILambdaContext lambdaContext);
+
+        /// <summary>
+        /// Subscribes to receive published messages of the specified type.
+        /// This method is only necessary if you turned off auto-subscribe.
+        /// </summary>
+        Task Subscribe(Type eventType, SubscribeOptions options, ILambdaContext lambdaContext);
+
+        /// <summary>
+        /// Subscribes to receive published messages of the specified type.
+        /// This method is only necessary if you turned off auto-subscribe.
+        /// </summary>
+        Task Subscribe(Type eventType, ILambdaContext lambdaContext);
+
+        /// <summary>
+        /// Unsubscribes to receive published messages of the specified type.
+        /// </summary>
+        Task Unsubscribe(Type eventType, UnsubscribeOptions options, ILambdaContext lambdaContext);
+
+        /// <summary>
+        /// Unsubscribes to receive published messages of the specified type.
+        /// </summary>
+        Task Unsubscribe(Type eventType, ILambdaContext lambdaContext);
+
     }
 }

--- a/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
+++ b/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="1.2.0" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="1.2.0" />
-    <PackageReference Include="NServiceBus.AmazonSQS" Version="[5.1.1, 6.0.0)" />
+    <PackageReference Include="NServiceBus.AmazonSQS" Version="5.1.1" />
     <PackageReference Include="Particular.CodeRules" Version="0.7.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
With this change, messages can be sent/published outside of the message handler, similar to what can be done with `IEndpointInstance` or `IMessageSession`.