### PR TITLE
Update repository license

### DIFF
--- a/.reposync.yml
+++ b/.reposync.yml
@@ -1,2 +1,0 @@
-exclusions:
-- LICENSE.md

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,10 @@
-By accessing the code here, you are agreeing to the following licensing terms.
+By accessing code under the [Particular Software GitHub Organization](https://github.com/Particular) (Particular Software) here, you are agreeing to the following licensing terms.
+If you do not agree to these terms, do not access Particular Software code.
 
-If you do not agree to these terms, do not access this code.
+Your license to Particular Software source code and/or binaries is governed by the Reciprocal Public License 1.5 (RPL1.5) license as described here: 
 
-You may use this source and/or binaries under the License Agreement described here:
+https://opensource.org/license/rpl-1-5/
 
-https://particular.net/eula/previews
+If you do not wish to release the source of software you build using Particular Software source code and/or binaries under the terms above, you may use Particular Software source code and/or binaries under the License Agreement described here:
+
+https://particular.net/LicenseAgreement


### PR DESCRIPTION
Version 1.0+ of this package is no longer under the preview license and instead falls under the standard license term.