### PR TITLE
Apply correct MinVer version increment setting for release branch

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <MinVerMinimumMajorMinor>1.0</MinVerMinimumMajorMinor>
-    <MinVerAutoIncrement>minor</MinVerAutoIncrement>
+    <MinVerAutoIncrement>patch</MinVerAutoIncrement>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Release branches should use patch increments as a default.