### PR TITLE
Remove workaround to not generate SBOM

### DIFF
--- a/src/NServiceBus.AwsLambda.SQS.Analyzer/NServiceBus.AwsLambda.SQS.Analyzer.csproj
+++ b/src/NServiceBus.AwsLambda.SQS.Analyzer/NServiceBus.AwsLambda.SQS.Analyzer.csproj
@@ -8,7 +8,6 @@
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
-    <GenerateSBOM>false</GenerateSBOM>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR removes the explicit set up to not generate a SBOM when it is not needed