### PR TITLE
Prepare for NServiceBus 10 - Remove LangVersion

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -7,7 +7,6 @@
   <PropertyGroup>
     <MinVerMinimumMajorMinor>4.0</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
-    
   </PropertyGroup>
 
 </Project>

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
 
   <PropertyGroup>
     <AnalyzerTargetFramework>netstandard2.0</AnalyzerTargetFramework>
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <MinVerMinimumMajorMinor>4.0</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
-    <LangVersion>preview</LangVersion>
+    
   </PropertyGroup>
 
 </Project>

--- a/src/NServiceBus.AwsLambda.SQS.Analyzer/NServiceBus.AwsLambda.SQS.Analyzer.csproj
+++ b/src/NServiceBus.AwsLambda.SQS.Analyzer/NServiceBus.AwsLambda.SQS.Analyzer.csproj
@@ -8,6 +8,7 @@
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Now that .NET 10 RC1 has been released, we don't need to set the language anymore.