### PR TITLE
Fix CVE ghsa-9cvc-h2w8-phrp8-phrp on 3.0

### DIFF
--- a/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
+++ b/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.5.1" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
     <PackageReference Include="NServiceBus" Version="9.2.7" />
-    <PackageReference Include="NServiceBus.AmazonSQS" Version="8.0.0" />
+    <PackageReference Include="NServiceBus.AmazonSQS" Version="8.0.1" />
     <PackageReference Include="Particular.Packaging" Version="4.2.2" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Result of fixing
- https://github.com/Particular/NServiceBus.AmazonSQS/issues/2977

NServiceBus.AwsLambda.Sqs 3.0.0 was indirectly affected by the CVE because it has a dependency on NServiceBus.AmazonSQS 8.0.0

This updates NServiceBus.AmazonSQS to 8.0.1 to patch the CVE.