### PR TITLE
Use property to control assembly package path

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -5,6 +5,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Package needs to stay on 5.0.x to ensure we run on the 10.0.10x SDK and Visual Studio 18.0 -->
+    <RoslynPackageVersion>5.0.0</RoslynPackageVersion>
+    <RoslynPackagePathVersion>$(RoslynPackageVersion.Split(`.`)[0]).$(RoslynPackageVersion.Split(`.`)[1])</RoslynPackagePathVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <MinVerMinimumMajorMinor>4.0</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
   </PropertyGroup>

--- a/src/NServiceBus.AwsLambda.SQS.Analyzer.Tests/NServiceBus.AwsLambda.SQS.Analyzer.Tests.csproj
+++ b/src/NServiceBus.AwsLambda.SQS.Analyzer.Tests/NServiceBus.AwsLambda.SQS.Analyzer.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.AwsLambda.SQS.Analyzer/NServiceBus.AwsLambda.SQS.Analyzer.csproj
+++ b/src/NServiceBus.AwsLambda.SQS.Analyzer/NServiceBus.AwsLambda.SQS.Analyzer.csproj
@@ -12,8 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Package needs to stay on 5.0.x to ensure we run on the 10.0.10x SDK and Visual Studio 18.0 -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
+++ b/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\NServiceBus.AwsLambda.SQS.Analyzer\bin\$(Configuration)\$(AnalyzerTargetFramework)\NServiceBus.AwsLambda.SQS.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn4.14/cs/NServiceBus.AwsLambda.SQS.Analyzer.dll" Visible="false" />
+    <None Include="..\NServiceBus.AwsLambda.SQS.Analyzer\bin\$(Configuration)\$(AnalyzerTargetFramework)\NServiceBus.AwsLambda.SQS.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/roslyn$(RoslynPackagePathVersion)/cs/NServiceBus.AwsLambda.SQS.Analyzer.dll" Visible="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR introduces properties to control the version of the Microsoft.CodeAnalysis packages and to calculate the resulting package path for the analyzer assemblies.