### PR TITLE
Bump NServiceBus.AmazonSQS to 8.1.2

### DIFF
--- a/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
+++ b/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.5.1" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
     <PackageReference Include="NServiceBus" Version="9.2.11" />
-    <PackageReference Include="NServiceBus.AmazonSQS" Version="8.1.1" />
+    <PackageReference Include="NServiceBus.AmazonSQS" Version="8.1.2" />
     <PackageReference Include="Particular.Packaging" Version="4.2.2" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
[#664](https://github.com/Particular/NServiceBus.AwsLambda.Sqs/issues/664) Update SQS transport to avoid delayed delivery bug caused by an [issue in the transport](https://github.com/Particular/NServiceBus.AmazonSQS/issues/3113)