### PR TITLE
Bump NServiceBus.AmazonSQS to 9.0.2

### DIFF
--- a/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
+++ b/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.8.0" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.1" />
     <PackageReference Include="NServiceBus" Version="10.1.4" />
-    <PackageReference Include="NServiceBus.AmazonSQS" Version="9.1.1" />
+    <PackageReference Include="NServiceBus.AmazonSQS" Version="9.0.2" />
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
+++ b/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.8.0" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.1" />
     <PackageReference Include="NServiceBus" Version="10.1.4" />
-    <PackageReference Include="NServiceBus.AmazonSQS" Version="9.0.2" />
+    <PackageReference Include="NServiceBus.AmazonSQS" Version="9.1.1" />
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
+++ b/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.8.0" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.1" />
     <PackageReference Include="NServiceBus" Version="10.1.4" />
-    <PackageReference Include="NServiceBus.AmazonSQS" Version="9.0.1" />
+    <PackageReference Include="NServiceBus.AmazonSQS" Version="9.0.2" />
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
[#664](https://github.com/Particular/NServiceBus.AwsLambda.Sqs/issues/664) Update SQS transport to avoid delayed delivery bug caused by an [issue in the transport](https://github.com/Particular/NServiceBus.AmazonSQS/issues/3113)