### PR TITLE
update NServiceBus.AmazonSQS to 9.1.1

### DIFF
--- a/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
+++ b/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Amazon.Lambda.Logging.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="3.0.0" />
     <PackageReference Include="NServiceBus" Version="10.2.0" />
-    <PackageReference Include="NServiceBus.AmazonSQS" Version="9.0.1" />
+    <PackageReference Include="NServiceBus.AmazonSQS" Version="9.1.1" />
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
+++ b/src/NServiceBus.AwsLambda.SQS/NServiceBus.AwsLambda.SQS.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="3.1.0" />
     <PackageReference Include="Amazon.Lambda.Logging.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="3.0.0" />
-    <PackageReference Include="NServiceBus" Version="10.2.0" />
+    <PackageReference Include="NServiceBus" Version="10.2.5" />
     <PackageReference Include="NServiceBus.AmazonSQS" Version="9.1.1" />
     <PackageReference Include="Particular.Packaging" Version="4.5.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
[#664](https://github.com/Particular/NServiceBus.AwsLambda.Sqs/issues/664) Update SQS transport to avoid delayed delivery bug caused by an [issue in the transport](https://github.com/Particular/NServiceBus.AmazonSQS/issues/3113)